### PR TITLE
Add: Param to specify filename for AddDelayedCode

### DIFF
--- a/lpcompiler.pas
+++ b/lpcompiler.pas
@@ -231,7 +231,7 @@ type
     function addGlobalMethod(AParams: array of TLapeType; AParTypes: array of ELapeParameterType; AParDefaults: array of TLapeGlobalVar; ARes: TLapeType; Value: TMethod; AName: lpString): TLapeGlobalVar; overload; virtual;
     function addGlobalMethod(AParams: array of TLapeType; AParTypes: array of ELapeParameterType; AParDefaults: array of TLapeGlobalVar; Value: TMethod; AName: lpString): TLapeGlobalVar; overload; virtual;
 
-    function addDelayedCode(ACode: lpString; AfterCompilation: Boolean = True; IsGlobal: Boolean = True; AFileName:String='Lape'): TLapeTree_Base; virtual;
+    function addDelayedCode(ACode: lpString; AfterCompilation: Boolean = True; IsGlobal: Boolean = True; AFileName:String='addDelayedCode'): TLapeTree_Base; virtual;
     
     property InternalMethodMap: TLapeInternalMethodMap read FInternalMethodMap;
     property Tree: TLapeTree_Base read FTree;


### PR DESCRIPTION
We now able to specify a file-name for addDelayedCode. This can
simplify debugging internal error for files added using AddDelayedCode.

Note: Simba has to be updated to compile with this change. See: https://github.com/MerlijnWajer/Simba/blob/master/Units/Misc/lpdump.pas#L27
